### PR TITLE
use `1>&2` to send `stdout` to `stderr`, replacing `2>&1` (fix #1)

### DIFF
--- a/hello
+++ b/hello
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo "Unsupported argument '$1'. Try --help." 2>&1
+      echo "Unsupported argument '$1'. Try --help." 1>&2
       exit 1
   esac
   shift

--- a/hello-teacher
+++ b/hello-teacher
@@ -74,10 +74,10 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      # Take care to write the error message to stderr (the '2' in '2>&1')
+      # Take care to write the error message to stderr (the '2' in '1>&2')
       # and exit with a non-zero status.
       #
-      echo "Unsupported argument '$1'. Try --help." 2>&1
+      echo "Unsupported argument '$1'. Try --help." 1>&2
       exit 1
   esac
   shift


### PR DESCRIPTION
partially undo 699aa81ba82252ea4b925acc2d464b82f43303fe

`1>&2` and its less verbose equivalent, `>&2` both have `2` or `stderr`
as their ultimate destination

[stackoverflow.com/q/2990414/echo-that-outputs-to-stderr](https://stackoverflow.com/a/2990533)
[mywiki.wooledge.org/BashFAQ/055](https://mywiki.wooledge.org/BashFAQ/055?rev=11&highlight=1%28%3E%262%29#line-21)